### PR TITLE
Fix `xcodegen` by adding `mint run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mint install yonaskolb/XcodeGen
 
 Generate xcodeproj by running command below.
 ```
-xcodegen
+mint run xcodegen
 ```
 
 Now you can open the xcodeproj, build it, and run.👌


### PR DESCRIPTION
- The instruction demanded installing `mint`, so `xcodegen` should be used via `mint`.