### PR TITLE
Fix crash when opening build trigger

### DIFF
--- a/BitriseClient/Sources/Realm/RealmManager.swift
+++ b/BitriseClient/Sources/Realm/RealmManager.swift
@@ -18,8 +18,11 @@ final class RealmManager {
             let objects = Config.workflowIDsMap
                 .map { (arg: (AppSlug, [WorkflowID])) -> BuildTriggerRealm in
                     let (appSlug, workflowIDs) = arg
+                    let gitObject = GitObject.branch("")
                     let properties: [String: Any?] = [
                         "appSlug": appSlug,
+                        "gitObjectValue": gitObject.associatedValue,
+                        "gitObjectType": gitObject.type,
                         "workflowIDs": workflowIDs,
                         "apiToken": NSNull(),
                     ]


### PR DESCRIPTION
The app was crashing on initial visit of build trigger pane.
It's due to force unwrapping missing property in realm object.

If you had encountered crashes, please **delete and reinstall the app** to apply this fix to your database.