### PR TITLE
Show error message on missing the Build Trigger Token for rebuild

### DIFF
--- a/BitriseClient/Sources/List/Builds/BuildsListViewModel.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewModel.swift
@@ -69,7 +69,11 @@ final class BuildsListViewModel {
             alertActions.append(AlertAction.init(title: "Rebuild", handler: { [weak self] _ in
                 guard let me = self else { return }
 
-                TriggerBuildAction.shared.sendRebuildRequest(appSlug: me.appSlug, build)
+                do {
+                    try TriggerBuildAction.shared.sendRebuildRequest(appSlug: me.appSlug, build)
+                } catch {
+                    me._alertMessage.value = "\(error)"
+                }
             }))
         }
 

--- a/BitriseClient/Sources/TriggerBuild/TriggerBuildAction.swift
+++ b/BitriseClient/Sources/TriggerBuild/TriggerBuildAction.swift
@@ -10,13 +10,20 @@ import RealmSwift
 
 final class TriggerBuildAction {
 
+    enum Error: Swift.Error, CustomStringConvertible {
+        case missingApiToken
+        var description: String {
+             return "Build Trigger Token is required. Please trigger build once to register a record in database."
+        }
+    }
+
     static let shared = TriggerBuildAction()
 
-    func sendRebuildRequest(appSlug: AppSlug, _ build: AppsBuilds.Build) {
+    func sendRebuildRequest(appSlug: AppSlug, _ build: AppsBuilds.Build) throws {
 
         let realm = Realm.getRealm()
         guard let token = realm.object(ofType: BuildTriggerRealm.self, forPrimaryKey: appSlug)?.apiToken else {
-            return
+            throw Error.missingApiToken
         }
 
         guard let url = URL(string: "https://app.bitrise.io/app/\(appSlug)/build/start.json") else {


### PR DESCRIPTION
Rebuild func was silently rejecting the user request.
Now it's more friendly.