### PR TITLE
Use os.signpost and os.log for better logging and profiling

### DIFF
--- a/BitriseClient/Sources/Extension/APIKit+Rx.swift
+++ b/BitriseClient/Sources/Extension/APIKit+Rx.swift
@@ -1,3 +1,4 @@
+import os.log
 import APIKit
 import RxSwift
 
@@ -11,8 +12,11 @@ extension Reactive where Base: Session {
                 case .success(let res):
                     o.onNext(res)
                     o.onCompleted()
-                case .failure(let err):
-                    o.onError(err)
+                case .failure(let error):
+                    if #available(iOS 12.0, *) {
+                        os_log(.error, log: .network, "%{public}@ error: %{public}@", req.path, error.localizedDescription)
+                    }
+                    o.onError(error)
                 }
             }
             return Disposables.create { [weak task] in

--- a/BitriseClient/Sources/List/Builds/BuildsListViewController.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewController.swift
@@ -1,3 +1,4 @@
+import os.log
 import APIKit
 import DeepDiff
 import RxSwift

--- a/BitriseClient/Sources/List/Builds/BuildsListViewModel.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewModel.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Core
 import DeepDiff
@@ -5,6 +6,8 @@ import Foundation
 import RxSwift
 import RxCocoa
 import UIKit
+
+private let log = OSLog(subsystem: "jp.toshi0383.BitriseClient.BuildList", category: "User")
 
 final class BuildsListViewModel {
 
@@ -215,7 +218,9 @@ final class BuildsListViewModel {
                 me.nextTokenMore.accept(appsBuilds.paging.next)
 
             case .failure(let error):
-                print(error)
+                if #available(iOS 12.0, *) {
+                    os_log(.error, "error %@", error.localizedDescription)
+                }
             }
 
             me._isLoading.accept(false)
@@ -230,7 +235,6 @@ final class BuildsListViewModel {
     ///     triggering pull-to-refresh causes droppping the next token for (850...801).
     ///
     func fetchBuilds(_ fetchMode: FetchMode) {
-
         if _isLoading.value { return }
         _isLoading.accept(true)
 
@@ -321,8 +325,9 @@ final class BuildsListViewModel {
                 me._dataChanges.accept(changes)
 
             case .failure(let error):
-                print(error)
-
+                if #available(iOS 12.0, *) {
+                    os_log(.error, "error %@", error.localizedDescription)
+                }
             }
 
             me._isLoading.accept(false)
@@ -336,6 +341,10 @@ final class BuildsListViewModel {
     }
 
     func updateScrollInfo(contentHeight: CGFloat, contentOffsetY: CGFloat, frameHeight: CGFloat, adjustedContentInsetBottom: CGFloat) {
+        if #available(iOS 12.0, *) {
+            os_signpost(.event, log: log, name: "updateScrollInfo")
+        }
+
         if contentHeight <= 0 {
             return
         }

--- a/Core/Api/AppsBuilds.swift
+++ b/Core/Api/AppsBuilds.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Foundation
 
@@ -9,6 +10,14 @@ public struct AppsBuildsRequest: BitriseAPIRequest {
 
     private let limit: Int
     private let next: String?
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
 
     public var queryParameters: [String : Any]? {
         var params: [String: Any] = ["limit": limit]

--- a/Core/Api/AppsBuildsAbort.swift
+++ b/Core/Api/AppsBuildsAbort.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Foundation
 
@@ -8,6 +9,14 @@ public struct AppsBuildsAbortRequest: BitriseAPIRequest {
     public let path: String
 
     public let method: HTTPMethod = .post
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
 
     public init(appSlug: String, buildSlug: String) {
         self.path = "/apps/\(appSlug)/builds/\(buildSlug)/abort"

--- a/Core/Api/BitriseAPIRequest.swift
+++ b/Core/Api/BitriseAPIRequest.swift
@@ -45,7 +45,7 @@ extension BitriseAPIRequest {
         if #available(iOS 12.0, *) {
             if let data = object as? Data {
                 if let spid = self.spid as? OSSignpostID {
-                    os_signpost(.end, log: .network, name: "BitriseAPIRequest", signpostID: spid, "Finished with size %{xcode:size-in-bytes}llu", data.count)
+                    os_signpost(.end, log: .network, name: "BitriseAPIRequest", signpostID: spid, "Finished with size %{xcode:size-in-bytes}llu, statusCode %{public}@, -statusCode %{private}@", data.count, urlResponse.statusCode.description, (urlResponse.statusCode * -1).description as NSString)
                 }
             }
         }

--- a/Core/Api/BitriseAPIRequest.swift
+++ b/Core/Api/BitriseAPIRequest.swift
@@ -45,7 +45,7 @@ extension BitriseAPIRequest {
         if #available(iOS 12.0, *) {
             if let data = object as? Data {
                 if let spid = self.spid as? OSSignpostID {
-                    os_signpost(.end, log: .network, name: "BitriseAPIRequest", signpostID: spid, "%{iec-bytes}d", data.count)
+                    os_signpost(.end, log: .network, name: "BitriseAPIRequest", signpostID: spid, "Finished with size %{xcode:size-in-bytes}llu", data.count)
                 }
             }
         }

--- a/Core/Api/BitriseAPIRequest.swift
+++ b/Core/Api/BitriseAPIRequest.swift
@@ -1,7 +1,9 @@
+import os.signpost
 import APIKit
 import Foundation
 
 public protocol BitriseAPIRequest: Request {
+    var spid: Any? { get }
     var personalAccessToken: String? { get }
 }
 
@@ -30,7 +32,30 @@ extension BitriseAPIRequest {
     }
 
     public func intercept(urlRequest: URLRequest) throws -> URLRequest {
+        if #available(iOS 12.0, *) {
+            if let spid = self.spid as? OSSignpostID {
+                os_signpost(.begin, log: .network, name: "BitriseAPIRequest", signpostID: spid, "%@", self.path)
+            }
+        }
+
         return urlRequest
+    }
+
+    public func intercept(object: Any, urlResponse: HTTPURLResponse) throws -> Any {
+        if #available(iOS 12.0, *) {
+            if let data = object as? Data {
+                if let spid = self.spid as? OSSignpostID {
+                    os_signpost(.end, log: .network, name: "BitriseAPIRequest", signpostID: spid, "%{iec-bytes}d", data.count)
+                }
+            }
+        }
+
+        // Copy of the default implementation in APIKit
+        guard 200..<300 ~= urlResponse.statusCode else {
+            throw ResponseError.unacceptableStatusCode(urlResponse.statusCode)
+        }
+
+        return object
     }
 }
 

--- a/Core/Api/GetBitriseYmlRequest.swift
+++ b/Core/Api/GetBitriseYmlRequest.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Foundation
 
@@ -21,6 +22,14 @@ public struct GetBitriseYmlRequest: BitriseAPIRequest {
     public var method: HTTPMethod {
         return .get
     }
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
 
     public init(appSlug: String) {
         self.path = "apps/\(appSlug)/bitrise.yml"

--- a/Core/Api/MeApps.swift
+++ b/Core/Api/MeApps.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Foundation
 
@@ -6,6 +7,14 @@ public struct MeAppsRequest: BitriseAPIRequest {
     public typealias Response = MeApps
 
     public let path: String = "/me/apps"
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
 
     public init() { }
 }

--- a/Core/Api/PostBitriseYmlRequet.swift
+++ b/Core/Api/PostBitriseYmlRequet.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Foundation
 
@@ -9,6 +10,14 @@ public struct PostBitriseYmlRequest: BitriseAPIRequest {
     public let path: String
     public let ymlString: String
     public let dataParser: DataParser = BitriseYmlDataParser()
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
 
     public var method: HTTPMethod {
         return .post

--- a/Core/Api/SingleBuildRequest.swift
+++ b/Core/Api/SingleBuildRequest.swift
@@ -1,3 +1,4 @@
+import os.signpost
 import APIKit
 import Foundation
 
@@ -6,6 +7,14 @@ public struct SingleBuildRequest: BitriseAPIRequest {
     public typealias Response = JSON
 
     public let path: String
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
 
     public init(appSlug: String, buildSlug: AppsBuilds.Build.Slug) {
         self.path = "/apps/\(appSlug)/builds/\(buildSlug)"

--- a/Core/OSLog.swift
+++ b/Core/OSLog.swift
@@ -1,5 +1,6 @@
-import os.signpost
+import os.log
 
 extension OSLog {
     public static let network = OSLog(subsystem: "jp.toshi0383.Bitrise-iOS.Core", category: "Network")
+    public static let ui = OSLog(subsystem: "jp.toshi0383.Bitrise-iOS", category: "UI")
 }

--- a/Core/OSLog.swift
+++ b/Core/OSLog.swift
@@ -1,0 +1,5 @@
+import os.signpost
+
+extension OSLog {
+    public static let network = OSLog(subsystem: "jp.toshi0383.Bitrise-iOS.Core", category: "Network")
+}


### PR DESCRIPTION
Now we can visualize network requests in instruments' "os_signpost" trace.
Network request/response performance is automatically logged via `os_signpost`.
<img width="1276" alt="screen shot 2018-10-26 at 11 24 14" src="https://user-images.githubusercontent.com/6007952/47540837-e685cd00-d911-11e8-856d-3f28168e64a4.png">

- [Fix Bugs Faster using Activity Tracing: WWDC 2014](https://developer.apple.com/videos/play/wwdc2014/714)
- [Unified Logging and Activity Tracing: WWDC 2016](https://developer.apple.com/videos/play/wwdc2016/721)
- [Measuring Performance Using Logging: WWDC 2018](https://developer.apple.com/videos/play/wwdc2018/405/)