### PR TITLE
Use slug to identify last visited app

### DIFF
--- a/BitriseClient/Sources/Config.swift
+++ b/BitriseClient/Sources/Config.swift
@@ -5,7 +5,7 @@ import UIKit
 
 protocol ConfigType {
     var personalAccessToken: String? { get }
-    var lastAppNameVisited: String? { get }
+    var lastAppSlugVisited: String? { get }
 }
 
 // - MARK: Config
@@ -31,18 +31,18 @@ final class Config: ConfigType {
         }
     }
 
-    // MARK: lastAppNameVisited
+    // MARK: lastAppSlugVisited
 
-    var lastAppNameVisited: String? {
+    var lastAppSlugVisited: String? {
         get {
             let realm = Realm.getRealm()
-            return realm.object(ofType: SettingsRealm.self, forPrimaryKey: "1")?.lastAppNameVisited
+            return realm.object(ofType: SettingsRealm.self, forPrimaryKey: "1")?.lastAppSlugVisited
         }
         set {
             let realm = Realm.getRealm()
             let settings = realm.object(ofType: SettingsRealm.self, forPrimaryKey: "1") ?? SettingsRealm()
             try! realm.write {
-                settings.lastAppNameVisited = newValue
+                settings.lastAppSlugVisited = newValue
                 realm.add(settings, update: true)
             }
         }

--- a/BitriseClient/Sources/List/Builds/BuildsListViewModel.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewModel.swift
@@ -14,8 +14,6 @@ final class BuildsListViewModel {
     /// lock for updateBuild
     private let updateBuildLock = NSLock()
 
-    private let appName: String
-
     var lifecycle: ViewControllerLifecycle! {
         didSet {
             lifecycle.viewDidLoad
@@ -23,7 +21,7 @@ final class BuildsListViewModel {
                     guard let me = self else { return }
 
                     // save app-title
-                    Config.shared.lastAppNameVisited = me.appName
+                    Config.shared.lastAppSlugVisited = me.appSlug
 
                     me.fetchDataAndReloadTable()
                 })
@@ -114,7 +112,6 @@ final class BuildsListViewModel {
          localNotificationAction: LocalNotificationAction = .shared,
          session: Session = .shared) {
         self.appSlug = appSlug
-        self.appName = appName
         self.navigationBarTitle = appName
         self.localNotificationAction = localNotificationAction
         self.session = session

--- a/BitriseClient/Sources/Realm/RealmManager.swift
+++ b/BitriseClient/Sources/Realm/RealmManager.swift
@@ -21,10 +21,14 @@ extension Realm {
             } catch {
                 print("Failed to open realm with error: \(error)")
 
+                #if !DEBUG
+                // Only delete realm file in production.
+                // I often make mistake writing migration block, and don't want to lose my data.
                 let fm = FileManager.default
                 if let fileURL = fileURL, fm.fileExists(atPath: fileURL.path) {
                     try fm.removeItem(at: fileURL)
                 }
+                #endif
 
                 return try Realm(configuration: config)
             }

--- a/BitriseClient/Sources/Realm/RealmManager.swift
+++ b/BitriseClient/Sources/Realm/RealmManager.swift
@@ -13,7 +13,23 @@ extension Realm {
 
             let key = getKey() as Data
             // print("fileURL: \(fileURL!), key: \(key.hexEncodedString(options: .upperCase))")
-            let config = Configuration(fileURL: fileURL, encryptionKey: key)
+            let config = Configuration(
+                fileURL: fileURL,
+                encryptionKey: key,
+                schemaVersion: 1,
+                migrationBlock: { migration, oldSchemaVersion in
+
+                    switch oldSchemaVersion {
+                    case 0:
+                        // schemaVersion 1: rename
+                        migration.renameProperty(onType: SettingsRealm.className(),
+                                                 from:  "lastAppNameVisited",
+                                                 to:    "lastAppSlugVisited")
+                    default:
+                        break
+                    }
+                }
+            )
 
             do {
                 return try Realm(configuration: config)

--- a/BitriseClient/Sources/Realm/SettingsRealm.swift
+++ b/BitriseClient/Sources/Realm/SettingsRealm.swift
@@ -4,7 +4,7 @@ import RealmSwift
 final class SettingsRealm: Object {
     @objc dynamic var pkey = "1"
     @objc dynamic var personalAccessToken: String?
-    @objc dynamic var lastAppNameVisited: String?
+    @objc dynamic var lastAppSlugVisited: String?
 
     override static func primaryKey() -> String? {
         return "pkey"

--- a/BitriseClient/Sources/Router.swift
+++ b/BitriseClient/Sources/Router.swift
@@ -44,8 +44,8 @@ final class Router {
                     me.appsManager.apps = res.data
 
                     let cond: (MeApps.App) -> Bool = {
-                        if let appname = me.config.lastAppNameVisited {
-                            return $0.title == appname
+                        if let appslug = me.config.lastAppSlugVisited {
+                            return $0.slug == appslug
                         } else {
                             return true
                         }

--- a/Tests/BitriseClientTests/Mock/MockConfig.swift
+++ b/Tests/BitriseClientTests/Mock/MockConfig.swift
@@ -7,7 +7,7 @@ final class MockConfig: ConfigType {
     }
 
     var lastAppSlugVisited: String? {
-        return "app-name-0"
+        return "app-slug-0"
     }
 
 }

--- a/Tests/BitriseClientTests/Mock/MockConfig.swift
+++ b/Tests/BitriseClientTests/Mock/MockConfig.swift
@@ -6,7 +6,7 @@ final class MockConfig: ConfigType {
         return "abcdefg"
     }
 
-    var lastAppNameVisited: String? {
+    var lastAppSlugVisited: String? {
         return "app-name-0"
     }
 

--- a/Tests/BitriseClientTests/Mock/MockMeApps.swift
+++ b/Tests/BitriseClientTests/Mock/MockMeApps.swift
@@ -10,8 +10,8 @@ extension MeApps {
                        repo_owner: "",
                        repo_slug: "",
                        repo_url: "",
-                       slug: "",
-                       title: "app-name-0")
+                       slug: "app-slug-0",
+                       title: "")
         ]
 
         let paging = Paging(page_item_limit: 25,


### PR DESCRIPTION
This is part of the app launch performance improvement project.
https://github.com/toshi0383/Bitrise-iOS/issues/57

We need to remember appSlug in order to fetch the app's builds before `/me/apps` request complete.

- [x] Do not delete realm during development
- [x] Use slug to identify last visited app
- [x] Impl **Realm migration** block