### PR TITLE
Build Log Downloader

### DIFF
--- a/BitriseClient/Sources/AppDelegate.swift
+++ b/BitriseClient/Sources/AppDelegate.swift
@@ -16,6 +16,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
+        DispatchQueue.global(qos: .background).async {
+            BuildLogDownloader.shared.removeOutdatedBuildLogs()
+        }
+
         Core.APIConfig.getToken = { Config.shared.personalAccessToken }
 
         // [ActionPopoverButton]

--- a/BitriseClient/Sources/List/Builds/BuildCell.swift
+++ b/BitriseClient/Sources/List/Builds/BuildCell.swift
@@ -1,4 +1,5 @@
 import Core
+import RxCocoa
 import RxSwift
 import UIKit
 
@@ -8,6 +9,13 @@ final class BuildCell: UITableViewCell {
     @IBOutlet private weak var branchLabel: UILabel!
     @IBOutlet private weak var subtitleLabel: UILabel!
     @IBOutlet private weak var subtitleLabel2: UILabel!
+
+    @IBOutlet private weak var logDownloadSlider: UISlider! {
+        didSet {
+            logDownloadSlider.isHidden = true
+            logDownloadSlider.value = 0
+        }
+    }
 
     @IBOutlet private weak var smallSquareView: UIView! {
         didSet {
@@ -55,6 +63,7 @@ extension BuildCell {
         branchLabel.text = nil
         subtitleLabel.text = nil
         subtitleLabel2.text = nil
+        logDownloadSlider.isHidden = true
     }
 
     func configure(_ build: AppsBuilds.Build) {
@@ -119,6 +128,23 @@ extension BuildCell {
 
                 // happens when aborted before it starts.
                 // assertionFailure("finished_at should exist")
+            }
+        }
+    }
+
+    var logDownloadState: Binder<BuildLogDownloader.DownloadProgress.State> {
+        return Binder(self) { base, state in
+            switch state {
+            case .initial:
+                base.logDownloadSlider.isHidden = true
+                base.backgroundColor = .white
+            case .inProgress(let progress):
+                base.logDownloadSlider.isHidden = false
+                base.logDownloadSlider.setValue(Float(progress), animated: true)
+                base.backgroundColor = .white
+            case .completed(_):
+                base.logDownloadSlider.isHidden = true
+                base.backgroundColor = UIColor(hex: 0xB2ECDE)
             }
         }
     }

--- a/BitriseClient/Sources/List/Builds/BuildCell.swift
+++ b/BitriseClient/Sources/List/Builds/BuildCell.swift
@@ -142,7 +142,7 @@ extension BuildCell {
                 base.logDownloadSlider.isHidden = false
                 base.logDownloadSlider.setValue(Float(progress), animated: true)
                 base.backgroundColor = .white
-            case .completed(_):
+            case .completed:
                 base.logDownloadSlider.isHidden = true
                 base.backgroundColor = UIColor(hex: 0xB2ECDE)
             }

--- a/BitriseClient/Sources/List/Builds/BuildCell.swift
+++ b/BitriseClient/Sources/List/Builds/BuildCell.swift
@@ -64,6 +64,7 @@ extension BuildCell {
         subtitleLabel.text = nil
         subtitleLabel2.text = nil
         logDownloadSlider.isHidden = true
+        backgroundColor = .white
     }
 
     func configure(_ build: AppsBuilds.Build) {

--- a/BitriseClient/Sources/List/Builds/BuildsListDataSource.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListDataSource.swift
@@ -37,6 +37,24 @@ final class BuildsListDataSource: NSObject, UITableViewDataSource {
                 .disposed(by: cell.reuseDisposeBag)
         }
 
+        Observable
+            .merge(
+                BuildLogDownloader.shared
+                    .removeProgress(forBuildSlug: build.slug)
+                    .flatMapLatest { progress in
+                        progress.completed.asObservable()
+                    }
+                    .map { _ in BuildLogDownloader.DownloadProgress.State.initial },
+
+                BuildLogDownloader.shared
+                    .downloadProgress(forBuildSlug: build.slug)
+                    .flatMapLatest { progress in
+                        progress.state.asObservable()
+                }
+            )
+            .bind(to: cell.logDownloadState)
+            .disposed(by: cell.reuseDisposeBag)
+
         return cell
     }
 

--- a/BitriseClient/Sources/List/Builds/BuildsListViewController.storyboard
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewController.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vBi-NG-FsP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vBi-NG-FsP">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,18 +22,23 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BuildCell" rowHeight="71" id="Koj-ll-T4n" customClass="BuildCell" customModule="BitriseClient" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="71"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BuildCell" rowHeight="81" id="Koj-ll-T4n" customClass="BuildCell" customModule="BitriseClient" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="81"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Koj-ll-T4n" id="BQu-o6-dqi">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="70.666666666666671"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="80.666666666666671"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
+                                                <slider opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="fKJ-Mg-VPY">
+                                                    <rect key="frame" x="-2" y="63.666666666666657" width="379" height="31"/>
+                                                    <color key="minimumTrackTintColor" red="0.29411764709999999" green="0.74901960779999999" blue="0.6588235294" alpha="1" colorSpace="deviceRGB"/>
+                                                    <color key="thumbTintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </slider>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="C2T-CV-fcv">
-                                                    <rect key="frame" x="8" y="7.9999999999999964" width="359" height="54.666666666666657"/>
+                                                    <rect key="frame" x="8" y="8" width="359" height="64.666666666666671"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="cES-ce-F5v">
-                                                            <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="39"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="40.666666666666664"/>
                                                             <subviews>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M3b-Hh-6o4">
                                                                     <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
@@ -44,7 +49,7 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="UDa-fS-K7z">
-                                                                    <rect key="frame" x="34" y="0.0" width="41.666666666666657" height="39"/>
+                                                                    <rect key="frame" x="34" y="0.0" width="41.666666666666657" height="40.666666666666664"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pjD-cH-trZ">
                                                                             <rect key="frame" x="0.0" y="0.0" width="41.666666666666664" height="20.333333333333332"/>
@@ -53,7 +58,7 @@
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AhJ-fg-qr4">
-                                                                            <rect key="frame" x="0.0" y="20.333333333333329" width="41.666666666666664" height="18.666666666666671"/>
+                                                                            <rect key="frame" x="0.0" y="20.333333333333336" width="41.666666666666664" height="20.333333333333336"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -63,7 +68,7 @@
                                                             </subviews>
                                                         </stackView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ot9-M1-9LR">
-                                                            <rect key="frame" x="0.0" y="39" width="70" height="15.666666666666664"/>
+                                                            <rect key="frame" x="0.0" y="49" width="70" height="15.666666666666671"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vnR-Nz-SKD">
                                                                     <rect key="frame" x="0.0" y="0.0" width="33" height="15.666666666666666"/>
@@ -83,14 +88,20 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="fKJ-Mg-VPY" secondAttribute="bottom" constant="-13" id="cn4-bn-jWL"/>
                                                 <constraint firstAttribute="bottom" secondItem="C2T-CV-fcv" secondAttribute="bottom" constant="8" id="iKH-vM-cFs"/>
                                                 <constraint firstAttribute="trailing" secondItem="C2T-CV-fcv" secondAttribute="trailing" constant="8" id="rAy-Zf-uOr"/>
                                                 <constraint firstItem="C2T-CV-fcv" firstAttribute="leading" secondItem="BQu-o6-dqi" secondAttribute="leading" constant="8" id="viy-DV-mHq"/>
                                                 <constraint firstItem="C2T-CV-fcv" firstAttribute="top" secondItem="BQu-o6-dqi" secondAttribute="top" constant="8" id="wcr-Qo-6jx"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <constraints>
+                                            <constraint firstItem="fKJ-Mg-VPY" firstAttribute="leading" secondItem="Koj-ll-T4n" secondAttribute="leading" id="IJJ-qX-6RA"/>
+                                            <constraint firstAttribute="trailing" secondItem="fKJ-Mg-VPY" secondAttribute="trailing" id="bcd-zT-ZHF"/>
+                                        </constraints>
                                         <connections>
                                             <outlet property="branchLabel" destination="AhJ-fg-qr4" id="h4N-ks-yW3"/>
+                                            <outlet property="logDownloadSlider" destination="fKJ-Mg-VPY" id="Xtz-Ey-mXF"/>
                                             <outlet property="smallSquareView" destination="M3b-Hh-6o4" id="SoT-QF-Ur8"/>
                                             <outlet property="subtitleLabel" destination="vnR-Nz-SKD" id="KTe-kw-cOR"/>
                                             <outlet property="subtitleLabel2" destination="kg8-TY-gkq" id="8fK-9v-oLJ"/>

--- a/BitriseClient/Sources/List/Builds/BuildsListViewController.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewController.swift
@@ -96,7 +96,9 @@ final class BuildsListViewController: UIViewController, Storyboardable {
         viewModel.dataChanges.changed
             .observeOn(ConcurrentMainScheduler.instance)
             .subscribe(onNext: { [weak self] changes in
-                self?.tableView.reload(changes: changes, completion: { _ in })
+                // FIXME: crash on initial reload
+                // self?.tableView.reload(changes: changes, completion: { _ in })
+                self?.tableView.reloadData()
             })
             .disposed(by: rx.disposeBag)
 

--- a/BitriseClient/Sources/List/Builds/BuildsListViewController.swift
+++ b/BitriseClient/Sources/List/Builds/BuildsListViewController.swift
@@ -85,6 +85,14 @@ final class BuildsListViewController: UIViewController, Storyboardable {
             })
             .disposed(by: rx.disposeBag)
 
+        viewModel.showBuildLog
+            .observeOn(ConcurrentMainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                let vc = LogViewController(build: $0)
+                self?.navigationController?.pushViewController(vc, animated: true)
+            })
+            .disposed(by: rx.disposeBag)
+
         viewModel.dataChanges.changed
             .observeOn(ConcurrentMainScheduler.instance)
             .subscribe(onNext: { [weak self] changes in
@@ -133,7 +141,16 @@ final class BuildsListViewController: UIViewController, Storyboardable {
 
         tableView.rx.itemSelected
             .subscribe(onNext: { [weak self] indexPath in
-                self?.tableView.deselectRow(at: indexPath, animated: true)
+                guard let me = self else { return }
+
+                let builds = me.viewModel.builds
+                if indexPath.row < builds.count {
+                    // TODO
+                    // let build = builds[indexPath.row]
+                    // let vc = BuildDetailViewController(build)
+                    // me.navigationController?.pushViewController(vc, animated: true)
+                }
+                me.tableView.deselectRow(at: indexPath, animated: true)
             })
             .disposed(by: rx.disposeBag)
 

--- a/BitriseClient/Sources/Log/BuildLogDownloader.swift
+++ b/BitriseClient/Sources/Log/BuildLogDownloader.swift
@@ -9,7 +9,6 @@ final class BuildLogDownloader {
     private var downloadTasks: [String: DownloadProgress] = [:]
     private var removeTasks: [String: RemoveProgress] = [:]
     private let fileRemoveScheduler = SerialDispatchQueueScheduler(qos: .background)
-    private let fileCopyScheduler = ConcurrentDispatchQueueScheduler(qos: .background)
     private let _newDownloadProgress = PublishRelay<DownloadProgress>()
     private let _newRemoveProgress = PublishRelay<RemoveProgress>()
 
@@ -78,7 +77,6 @@ extension BuildLogDownloader {
         progress.task = task
 
         progress.state.asObservable()
-            .observeOn(fileCopyScheduler)
             .subscribe(onNext: { [unowned self] state in
 
                 if case .completed = state {
@@ -278,7 +276,7 @@ extension BuildLogDownloader.DownloadProgress: URLSessionDownloadDelegate {
             mkdirIfNeeded(destFileURL.deletingLastPathComponent())
             try fm.moveItem(at: location, to: destFileURL)
         } catch {
-            print("[error] during copying downloaded log file. Error: \(error)")
+            print("[error] during moving downloaded log file. Error: \(error)")
         }
 
         _completed.accept(())

--- a/BitriseClient/Sources/Log/BuildLogDownloader.swift
+++ b/BitriseClient/Sources/Log/BuildLogDownloader.swift
@@ -1,0 +1,307 @@
+import Foundation
+import RxCocoa
+import RxSwift
+
+final class BuildLogDownloader {
+
+    private let destDir = URL(fileURLWithPath: NSHomeDirectory().appending("/Library/Caches/LogFiles/"))
+    private let fm: FileManager = .default
+    private var downloadTasks: [String: DownloadProgress] = [:]
+    private var removeTasks: [String: RemoveProgress] = [:]
+    private let fileRemoveScheduler = SerialDispatchQueueScheduler(qos: .background)
+    private let fileCopyScheduler = ConcurrentDispatchQueueScheduler(qos: .background)
+    private let _newDownloadProgress = PublishRelay<DownloadProgress>()
+    private let _newRemoveProgress = PublishRelay<RemoveProgress>()
+
+    static let shared = BuildLogDownloader()
+
+    private init() { }
+
+}
+
+// MARK: API
+
+extension BuildLogDownloader {
+
+    func isDownloaded(_ buildSlug: String) -> Bool {
+        return fm.fileExists(atPath: fileURL(forBuildSlug: buildSlug).path)
+    }
+
+    func downloadProgress(forBuildSlug slug: String) -> Observable<DownloadProgress> {
+        if let progress = downloadTasks.first(where: { (_, progress) in progress.buildSlug == slug })?.value {
+            return .just(progress)
+        } else {
+            return _newDownloadProgress.filter { $0.buildSlug == slug }
+        }
+    }
+
+    func removeProgress(forBuildSlug slug: String) -> Observable<RemoveProgress> {
+        if let progress = removeTasks.first(where: { (_, progress) in progress.buildSlug == slug })?.value {
+            return .just(progress)
+        } else {
+            return _newRemoveProgress.filter { $0.buildSlug == slug }
+        }
+    }
+
+    @discardableResult
+    func enqueue(url: String, buildSlug: String) -> DownloadProgress {
+        print("start download for url: \(url), buildSlug: \(buildSlug)")
+
+        let destFileURL = self.fileURL(forBuildSlug: buildSlug)
+
+        let progress = DownloadProgress(url: url,
+                                        buildSlug: buildSlug,
+                                        destFileURL: destFileURL)
+        downloadTasks[url] = progress
+        _newDownloadProgress.accept(progress)
+
+        let configuration = URLSessionConfiguration
+            .background(withIdentifier:
+                "jp.toshi0383.Bitrise-iOS.BuildLogDownloader.\(buildSlug)")
+
+        configuration.allowsCellularAccess = false
+
+        let session = URLSession(configuration: configuration,
+                                 delegate: progress,
+                                 delegateQueue: OperationQueue())
+
+        let task = session.downloadTask(with: URL(string: url)!)
+
+        progress.task = task
+
+        progress.state.asObservable()
+            .observeOn(fileCopyScheduler)
+            .subscribe(onNext: { [unowned self] state in
+
+                if case .completed = state {
+                    self.cleanDownloadTaskIfExists(buildSlug: buildSlug)
+                }
+            })
+            .disposed(by: progress.rx.disposeBag)
+
+        // Invalidate session once finished.
+        // So same session Identifier can be reused.
+        session.finishTasksAndInvalidate()
+
+        task.resume()
+
+        return progress
+    }
+
+    /// Reads whole data from disk if exists.
+    /// Could be expensive process.
+    func data(forBuildSlug string: String) -> Data? {
+        let url = fileURL(forBuildSlug: string)
+
+        if !isRemoving(string) && fm.fileExists(atPath: url.path) {
+            return fm.contents(atPath: url.path)
+        }
+
+        return nil
+    }
+
+    @discardableResult
+    func removeData(forBuildSlug buildSlug: String) -> RemoveProgress? {
+        if !fm.fileExists(atPath: fileURL(forBuildSlug: buildSlug).path) {
+            return nil
+        }
+
+        let progress = RemoveProgress(buildSlug: buildSlug)
+
+        removeTasks[buildSlug] = progress
+        _newRemoveProgress.accept(progress)
+
+        cleanDownloadTaskIfExists(buildSlug: buildSlug)
+
+        progress._completed
+            .subscribe(onNext: { [unowned self] in
+                self.removeTasks[buildSlug] = nil
+            })
+            .disposed(by: progress.disposeBag)
+
+        startRemove(progress)
+
+        return progress
+    }
+}
+
+// MARK: Utilities
+
+extension BuildLogDownloader {
+
+    /// Reads whole data from disk if exists.
+    /// Could be expensive process.
+    func wholeText(forBuildSlug string: String) -> String? {
+
+        if let data = data(forBuildSlug: string) {
+            return String(data: data, encoding: .utf8)!
+        }
+
+        return nil
+
+    }
+
+    private func cleanDownloadTaskIfExists(buildSlug: String) {
+        for (url, progress) in downloadTasks {
+            if progress.buildSlug == buildSlug {
+                downloadTasks[url]?.task?.cancel()
+                downloadTasks[url] = nil
+            }
+        }
+    }
+
+    private func startRemove(_ progress: RemoveProgress) {
+        let fm = self.fm
+        let filePath = fileURL(forBuildSlug: progress.buildSlug).path
+
+        Observable
+            .create { o in
+                do {
+                    try fm.removeItem(atPath: filePath)
+                    o.onNext(())
+                    o.onCompleted()
+                } catch {
+                    o.onError(error)
+                }
+                return Disposables.create()
+            }
+            .subscribeOn(fileRemoveScheduler)
+            .bind(to: progress._completed)
+            .disposed(by: progress.disposeBag)
+    }
+
+    private func isRemoving(_ url: String) -> Bool {
+        return removeTasks[url] != nil
+    }
+
+    private func fileURL(forBuildSlug buildSlug: String) -> URL {
+        return destDir.appendingPathComponent("\(buildSlug).log")
+    }
+
+}
+
+extension BuildLogDownloader {
+
+    final class DownloadProgress: NSObject {
+        private let url: String
+        private let destFileURL: URL
+        let buildSlug: String
+        fileprivate var task: URLSessionDownloadTask?
+        private let fm: FileManager
+
+        fileprivate let _progress = BehaviorRelay<Double>(value: 0)
+        fileprivate let _completed = PublishRelay<URL>()
+
+        private let disposeBag = DisposeBag()
+
+        init(url: String,
+             buildSlug: String,
+             destFileURL: URL,
+             fm: FileManager = .default) {
+            self.url = url
+            self.buildSlug = buildSlug
+            self.destFileURL = destFileURL
+            self.fm = fm
+        }
+
+        var state: Property<State> {
+            let completed = _completed.asObservable()
+                .map { State.completed($0) }
+                .share()
+
+            return Property(unsafeObservable:
+                Observable.merge(
+                    Observable.just(.initial),
+                    _progress.asObservable()
+                        .map { State.inProgress($0) }
+                        .takeUntil(completed).debug("[state-0]"),
+                    completed.debug("[state-1]")
+                )
+            )
+        }
+
+        enum State {
+            case initial
+            case inProgress(Double)
+            case completed(URL)
+        }
+    }
+
+    final class RemoveProgress {
+        fileprivate let buildSlug: String
+        fileprivate let disposeBag = DisposeBag()
+
+        /// May emit error.
+        fileprivate let _completed = PublishSubject<Void>()
+
+        let completed: Observable<Void>
+
+        init(buildSlug: String) {
+            self.buildSlug = buildSlug
+            self.completed = _completed.catchError { _ in .empty() }
+        }
+    }
+
+}
+
+extension BuildLogDownloader.DownloadProgress: URLSessionDownloadDelegate {
+
+    func urlSession(_ session: URLSession,
+                    downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+
+        print("[didFinishDownloadingTo] location: \(location), downloadTask.state: \(downloadTask.state)")
+
+        // File move must be done here, not in the down stream of _completed.
+        // By that time, the file at `location` is deleted. (seems too fast to me..)
+        // It didn't matter if you subscribe without scheduler, which should be called synchronously.
+        do {
+            mkdirIfNeeded(destFileURL.deletingLastPathComponent())
+            try fm.moveItem(at: location, to: destFileURL)
+        } catch {
+            print("[error] during copying downloaded log file. Error: \(error)")
+        }
+
+        _completed.accept(location)
+    }
+
+    func urlSession(_ session: URLSession,
+                    downloadTask: URLSessionDownloadTask,
+                    didResumeAtOffset fileOffset: Int64,
+                    expectedTotalBytes: Int64) {
+
+        print("[didResumeAtOffset] fileOffset: \(fileOffset), expectedTotalBytes: \(expectedTotalBytes), downloadTask.state: \(downloadTask.state)")
+
+    }
+
+    func urlSession(_ session: URLSession,
+                    downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64,
+                    totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite) * 100
+
+        print("[didWriteData] progress: \(progress), downloadTask.state: \(downloadTask.state)")
+
+        _progress.accept(progress)
+    }
+}
+
+private func mkdirIfNeeded(_ url: URL) {
+    if !url.isFileURL {
+        fatalError("non-file URL is not supported")
+    }
+
+    let fm = FileManager.default
+    if fm.fileExists(atPath: url.path) {
+        return
+    }
+
+    do {
+        try fm.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+    } catch {
+        print("[error] during creating directory: \(error)")
+    }
+
+}

--- a/BitriseClient/Sources/Log/LogViewController.swift
+++ b/BitriseClient/Sources/Log/LogViewController.swift
@@ -1,0 +1,68 @@
+import Core
+import Highlightr
+import RxCocoa
+import RxSwift
+import UIKit
+
+final class LogViewController: UIViewController {
+
+    private let build: AppsBuilds.Build
+
+    init(build: AppsBuilds.Build) {
+        self.build = build
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private let textView: UITextView = {
+
+        let textStorage = CodeAttributedString()
+        textStorage.language = "console"
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+
+        let textContainer = NSTextContainer(size: .zero)
+        layoutManager.addTextContainer(textContainer)
+
+        let tv = UITextView(frame: .zero, textContainer: textContainer)
+        tv.isEditable = false
+        tv.tintColor = .white // cursor color
+        tv.backgroundColor = textStorage.highlightr.theme.themeBackgroundColor
+        tv.contentInset = .zero
+        return tv
+    }()
+}
+
+// MARK: Lifecycle
+
+extension LogViewController {
+
+    override func viewDidLoad() {
+
+        super.viewDidLoad()
+
+        navigationItem.title = "#\(build.build_number)"
+
+        view.backgroundColor = (textView.textStorage as! CodeAttributedString).highlightr.theme.themeBackgroundColor
+
+        do {
+            view.addSubview(textView)
+
+            textView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                textView.topAnchor.constraint(equalTo: view.topAnchor),
+                textView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                ])
+
+            if let data = BuildLogDownloader.shared.data(forBuildSlug: build.slug),
+                let text = String(data: data, encoding: .utf8) {
+
+                textView.text = text
+            }
+        }
+
+    }
+}

--- a/Core/Api/AppsBuildsLog.swift
+++ b/Core/Api/AppsBuildsLog.swift
@@ -1,0 +1,45 @@
+import os.signpost
+import APIKit
+import Foundation
+
+public struct AppsBuildsLogRequest: BitriseAPIRequest {
+
+    public typealias Response = AppsBuildsLog
+
+    public let path: String
+
+    public let method: HTTPMethod = .get
+
+    public let spid: Any? = {
+        if #available(iOS 12.0, *) {
+            return OSSignpostID(log: .network)
+        } else {
+            return nil
+        }
+    }()
+
+    public init(appSlug: String, buildSlug: String) {
+        self.path = "/apps/\(appSlug)/builds/\(buildSlug)/log"
+    }
+}
+
+public struct AppsBuildsLog: Decodable {
+
+    public let expiring_raw_log_url: String
+    public let generated_log_chunks_num: Int
+    public let is_archived: Bool
+    public let log_chunks: [Chunk]
+    public let timestamp: Date?
+
+}
+
+extension AppsBuildsLog {
+
+  public struct Chunk: Decodable {
+
+      public let chunk: String
+      public let position: Int
+
+  }
+
+}

--- a/project.yml
+++ b/project.yml
@@ -10,7 +10,7 @@ targets:
     type: application
     sources:
       - BitriseClient
-      - RxProperty/RxProperty.swift
+      - RxProperty/Sources/RxProperty/RxProperty.swift
     configFiles:
       Debug: configs/BitriseClient-Debug.xcconfig
       Release: configs/BitriseClient-Release.xcconfig


### PR DESCRIPTION
#32 

Added build log download feature.
Files are automatically deleted after 7 days.

## Screenshot

| Download via ActionSheet | LogViewController |
|---|---|
| ![output](https://user-images.githubusercontent.com/6007952/54433818-196d1800-4770-11e9-9ea1-772c6af06441.gif) | ![IMG_6544](https://user-images.githubusercontent.com/6007952/54433926-62bd6780-4770-11e9-95af-5f83a12e5add.PNG) |

## LogViewController

### Performance issue

It takes too long to colorize large log file with Highlightr.
We should consider range access to the file instead of loading all content of the file at once.
I leave this as future TODO for now.

### Color issue

Bitrise emits [bash color format](https://misc.flogisoft.com/bash/tip_colors_and_formatting), so may be  we can manually parse it to show cool colors like we see on Bitrise web console.

<img width="712" alt="Screen Shot 2019-03-15 at 22 25 48" src="https://user-images.githubusercontent.com/6007952/54434323-54238000-4771-11e9-869a-c0ed0b1c019b.png">

Is there any framework or 3rd party tool to do that on iOS `UITextView` ?