### PR TITLE
Add prompt for large log file to allow download under cellular network

### DIFF
--- a/BitriseClient/Sources/Extension/Observable.swift
+++ b/BitriseClient/Sources/Extension/Observable.swift
@@ -47,3 +47,13 @@ extension BehaviorRelay {
 func void<E>(_ x: E) {
     return Void()
 }
+
+extension ObservableType {
+    static func justOrEmpty<E>(_ x: E?) -> Observable<E> {
+        if let x = x {
+            return .just(x)
+        } else {
+            return .empty()
+        }
+    }
+}

--- a/BitriseClient/Sources/Log/BuildLogDownloader.swift
+++ b/BitriseClient/Sources/Log/BuildLogDownloader.swift
@@ -62,28 +62,28 @@ extension BuildLogDownloader {
     }
 
     @discardableResult
-    func enqueue(url: String, buildSlug: String) -> DownloadProgress {
+    func enqueue(url: URL, buildSlug: String) -> DownloadProgress {
         print("start download for url: \(url), buildSlug: \(buildSlug)")
 
         let destFileURL = self.fileURL(forBuildSlug: buildSlug)
 
-        let progress = DownloadProgress(url: url,
+        let progress = DownloadProgress(url: url.absoluteString,
                                         buildSlug: buildSlug,
                                         destFileURL: destFileURL)
-        downloadTasks[url] = progress
+        downloadTasks[url.absoluteString] = progress
         _newDownloadProgress.accept(progress)
 
         let configuration = URLSessionConfiguration
             .background(withIdentifier:
                 "jp.toshi0383.Bitrise-iOS.BuildLogDownloader.\(buildSlug)")
 
-        configuration.allowsCellularAccess = false
+        configuration.allowsCellularAccess = true
 
         let session = URLSession(configuration: configuration,
                                  delegate: progress,
                                  delegateQueue: OperationQueue())
 
-        let task = session.downloadTask(with: URL(string: url)!)
+        let task = session.downloadTask(with: url)
 
         progress.task = task
 

--- a/Core/Utils.swift
+++ b/Core/Utils.swift
@@ -1,3 +1,35 @@
+import Foundation
+import RxCocoa
+import RxSwift
+
 public func isTest() -> Bool {
     return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+}
+
+/// https://discuss.bitrise.io/t/build-logs-size-before-download/8614
+public func sizeRequestUsingZeroRange(_ url: URL) -> Observable<Int64> {
+    var req = URLRequest(url: url)
+    req.setValue("bytes=0-0", forHTTPHeaderField: "Range")
+
+    return URLSession.shared
+        .rx.response(request: req)
+        .flatMap { (res, _) -> Observable<Int64> in
+
+            if let resrange = res.allHeaderFields["Content-Range"] as? String {
+
+                // bytes 0-0/9553
+                if let total = resrange.split(separator: "/").last {
+
+                    let bf = ByteCountFormatter()
+                    bf.countStyle = .file
+
+                    if let bytes = Int64(String(total)) {
+                        return .just(bytes)
+                    }
+
+                }
+            }
+
+            return .empty()
+        }
 }


### PR DESCRIPTION
Prompt user when download file size is more than almost 1.0 MB (`1_000_000` bytes).
![Simulator Screen Shot - iPhone 7 - 2019-04-03 at 01 48 14](https://user-images.githubusercontent.com/6007952/55420773-c76f2380-55b2-11e9-8dc3-0baa3034478f.png)

discussion:
https://discuss.bitrise.io/t/build-logs-size-before-download/8614